### PR TITLE
Remove depracation warnings

### DIFF
--- a/lib/athena_health/department.rb
+++ b/lib/athena_health/department.rb
@@ -2,7 +2,7 @@ module AthenaHealth
   class Department < BaseModel
     attribute :creditcardtypes,              Array
     attribute :medicationhistoryconsent,     Boolean
-    attribute :timezoneoffset,               Fixnum
+    attribute :timezoneoffset,               Integer
     attribute :providergroupid,              Integer
     attribute :singleappointmentcontractmax, Integer
     attribute :state,                        String
@@ -18,7 +18,7 @@ module AthenaHealth
     attribute :placeofservicetypeid,         Integer
     attribute :longitude,                    Float
     attribute :clinicals,                    String
-    attribute :timezone,                     Fixnum
+    attribute :timezone,                     Integer
     attribute :patientdepartmentname,        String
     attribute :name,                         String
     attribute :placeofservicetypename,       String

--- a/spec/lib/analyte_spec.rb
+++ b/spec/lib/analyte_spec.rb
@@ -27,7 +27,6 @@ describe AthenaHealth::Analyte do
       value: '80',
       analytename: 'HDL',
       analyteid: 402,
-      analytedate: '06\/18\/2010',
       loinc: 'Logical observations',
       units: 'units',
       analytedate: '06\/18\/2010',


### PR DESCRIPTION
```
/Users/mateuszurbanski/projects/athena_health/lib/athena_health/department.rb:5: warning: constant ::Fixnum is deprecated
/Users/mateuszurbanski/projects/athena_health/lib/athena_health/department.rb:21: warning: constant ::Fixnum is deprecated
/Users/mateuszurbanski/projects/athena_health/spec/lib/analyte_spec.rb:30: warning: key :analytedate is duplicated and overwritten on line 33
```