### PR TITLE
Bump version to 1.0.50

### DIFF
--- a/lib/athena_health/version.rb
+++ b/lib/athena_health/version.rb
@@ -1,3 +1,3 @@
 module AthenaHealth
-  VERSION = '1.0.49'.freeze
+  VERSION = '1.0.50'.freeze
 end


### PR DESCRIPTION
Saw that this was committed: https://github.com/HealthTechDevelopers/athena_health/pull/49

Just updated the Gem version so I can bundle and not have the deprecation warnings as well.

Thanks!